### PR TITLE
로그인, 회원가입 구현 완료

### DIFF
--- a/src/main/java/com/mini/anuualwork/config/ApiConfig.java
+++ b/src/main/java/com/mini/anuualwork/config/ApiConfig.java
@@ -1,0 +1,13 @@
+package com.mini.anuualwork.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class ApiConfig {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/mini/anuualwork/config/AuthenticationConfig.java
+++ b/src/main/java/com/mini/anuualwork/config/AuthenticationConfig.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -20,7 +22,10 @@ public class AuthenticationConfig {
 
     @Value("${jwt.secret}")
     private String secretKey;
+
+
     private final UserService userService;
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -29,8 +34,8 @@ public class AuthenticationConfig {
                 .csrf().disable()
                 .cors().and()
                 .authorizeRequests()
-                .antMatchers("/api/login").permitAll() //login은 모든 접근 허용함
-                .antMatchers(HttpMethod.POST,"/api/**").authenticated()
+                .antMatchers("/api/login", "/api/signup").permitAll() //login은 모든 접근 허용함
+//                .antMatchers(HttpMethod.POST,"/api/**").authenticated()
                 .and()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // jwt사용하는 경우 쓴다는데 더 공부해야 할듯?(to do)

--- a/src/main/java/com/mini/anuualwork/controller/UserController.java
+++ b/src/main/java/com/mini/anuualwork/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.mini.anuualwork.controller;
 
-import com.mini.anuualwork.dto.LoginTestDto;
+import com.mini.anuualwork.core.ApiDataResponse;
+import com.mini.anuualwork.dto.LoginDto;
+import com.mini.anuualwork.dto.SignupDto;
 import com.mini.anuualwork.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,13 +18,18 @@ public class UserController {
    private final UserService userService;
 
    @RequestMapping(value = "/api/login", method = RequestMethod.POST)
-   public ResponseEntity<String> login(@RequestBody LoginTestDto loginTestDto){
-       return ResponseEntity.ok().body(userService.login(loginTestDto.getUserName(),loginTestDto.getPassword()));
+   public ApiDataResponse<LoginDto.ResponseLoginSuccess> login(@RequestBody LoginDto loginDto){
+       return userService.login(loginDto.getEmail(),loginDto.getPassword());
    }
 
    @PostMapping("/api/test")
    public ResponseEntity<String> test(Authentication authentication){
        return ResponseEntity.ok().body(authentication.getName());
    }
+
+    @RequestMapping(value = "/api/signup", method = RequestMethod.POST)
+    public ApiDataResponse<SignupDto.ResponseSignupSuccess> signup(@RequestBody SignupDto signupDto){
+       return userService.join(signupDto);
+    }
 
 }

--- a/src/main/java/com/mini/anuualwork/core/ApiDataResponse.java
+++ b/src/main/java/com/mini/anuualwork/core/ApiDataResponse.java
@@ -11,3 +11,6 @@ public class ApiDataResponse<T> {
         this.data = data;
     }
 }
+
+
+

--- a/src/main/java/com/mini/anuualwork/dto/LoginDto.java
+++ b/src/main/java/com/mini/anuualwork/dto/LoginDto.java
@@ -1,0 +1,31 @@
+package com.mini.anuualwork.dto;
+
+import com.mini.anuualwork.entity.type.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class LoginDto {
+
+    private String email;
+    private String password;
+
+
+
+
+    @Data
+    public static class LoginMemberDto{
+        String email;
+        String name;
+        String employeeNumber;
+        MemberRole role;
+    }
+
+
+    @Data
+    @AllArgsConstructor
+    public static class ResponseLoginSuccess{
+        LoginMemberDto user;
+        private String token;
+    }
+}

--- a/src/main/java/com/mini/anuualwork/dto/LoginTestDto.java
+++ b/src/main/java/com/mini/anuualwork/dto/LoginTestDto.java
@@ -1,9 +1,0 @@
-package com.mini.anuualwork.dto;
-
-import lombok.Data;
-
-@Data
-public class LoginTestDto {
-    String userName;
-    String password;
-}

--- a/src/main/java/com/mini/anuualwork/dto/SignupDto.java
+++ b/src/main/java/com/mini/anuualwork/dto/SignupDto.java
@@ -1,0 +1,38 @@
+package com.mini.anuualwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+public class SignupDto {
+
+    @Email(message = "이메일 형식에 어긋납니다.")
+    @NotBlank(message = "이메일은 필수 입력 사항입니다.")
+    private String email;
+
+    @NotBlank(message = "이름은 필수 입력 사항입니다.")
+    @Size(max = 20,message = "이름은 최대 20글자입니다.")
+    private String name;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8,message = "비밀번호는 최소 8글자 입니다.")
+    private String password;
+
+    private String employeeNumber;
+
+
+
+    @Data
+    public static class ResponseSignupSuccess{
+        private String message = "회원가입에 성공했습니다.";
+    }
+
+
+
+
+}

--- a/src/main/java/com/mini/anuualwork/exception/UserException.java
+++ b/src/main/java/com/mini/anuualwork/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.mini.anuualwork.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+    public UserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/mini/anuualwork/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mini/anuualwork/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.mini.anuualwork.exception.handler;
 
 import com.mini.anuualwork.core.ApiErrorResponse;
+import com.mini.anuualwork.exception.UserException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,6 +12,12 @@ public class GlobalExceptionHandler {
     public ApiErrorResponse handleException(Exception exception) {
         String[] errorMessages = {exception.getMessage()};
 
+        return new ApiErrorResponse(errorMessages);
+    }
+
+    @ExceptionHandler(UserException.class)
+    public ApiErrorResponse handleUserException(UserException userException) {
+        String[] errorMessages = {userException.getMessage()};
         return new ApiErrorResponse(errorMessages);
     }
 

--- a/src/main/java/com/mini/anuualwork/repository/LoginMemberRepository.java
+++ b/src/main/java/com/mini/anuualwork/repository/LoginMemberRepository.java
@@ -1,0 +1,11 @@
+package com.mini.anuualwork.repository;
+
+import com.mini.anuualwork.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LoginMemberRepository extends JpaRepository<Member,Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/mini/anuualwork/service/UserService.java
+++ b/src/main/java/com/mini/anuualwork/service/UserService.java
@@ -1,18 +1,79 @@
 package com.mini.anuualwork.service;
 
+import com.mini.anuualwork.core.ApiDataResponse;
+import com.mini.anuualwork.dto.LoginDto;
+import com.mini.anuualwork.dto.SignupDto;
+import com.mini.anuualwork.entity.Member;
+import com.mini.anuualwork.entity.type.MemberRole;
+import com.mini.anuualwork.repository.LoginMemberRepository;
 import com.mini.anuualwork.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     @Value("${jwt.secret}")
     private String secretKey;
+
     private Long expriedMs = 1000 * 60 * 60l;
 
-    public String login(String userName,String password){
+    @Autowired
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
 
-        return JwtUtil.createJwt(userName,secretKey,expriedMs);
+    private final LoginMemberRepository loginMemberRepository;
+
+
+
+    public ApiDataResponse<LoginDto.ResponseLoginSuccess> login(String email, String password){
+
+        Member member = loginMemberRepository.findByEmail(email).
+                orElseThrow(() -> new RuntimeException("잘못된 이메일입니다."));
+
+        //비밀번호 DB와 검증
+        if(!bCryptPasswordEncoder.matches(password, member.getPassword()))
+            throw new RuntimeException("잘못된 비밀번호입니다.");
+
+        LoginDto.LoginMemberDto loginMemberDto = new LoginDto.LoginMemberDto();
+        loginMemberDto.setEmail(member.getEmail());
+        loginMemberDto.setName(member.getName());
+        loginMemberDto.setRole(member.getMemberRole());
+        loginMemberDto.setEmployeeNumber(member.getEmployeeNumber());
+
+
+        //성공한다면, jwt 줌.
+        String token = JwtUtil.createJwt(email,secretKey,expriedMs);
+
+        return new ApiDataResponse<>(new LoginDto.ResponseLoginSuccess(loginMemberDto,token));
+    }
+
+    public ApiDataResponse<SignupDto.ResponseSignupSuccess> join(SignupDto joinRequestDto){
+
+        //이메일 중복 검사.
+        if(loginMemberRepository.findByEmail(joinRequestDto.getEmail()).isPresent()){
+            throw new RuntimeException("이미 가입된 이메일 입니다.");
+        }
+
+
+        Member member = new Member();
+        member.setId(1l);
+        member.setEmail(joinRequestDto.getEmail());
+        member.setMemberRole(MemberRole.ROLE_USER);
+        member.setPassword(bCryptPasswordEncoder.encode(joinRequestDto.getPassword()));
+        member.setEmployeeNumber(joinRequestDto.getEmployeeNumber());
+        member.setName(joinRequestDto.getName());
+        loginMemberRepository.save(member);
+        log.info("회원가입 처리가 완료되었습니다. {}",member);
+        return new ApiDataResponse<>(new SignupDto.ResponseSignupSuccess());
+
+
     }
 }
+
+

--- a/src/main/java/com/mini/anuualwork/utils/JwtUtil.java
+++ b/src/main/java/com/mini/anuualwork/utils/JwtUtil.java
@@ -20,13 +20,12 @@ public class JwtUtil {
                 .getBody().getExpiration().before(new Date());
     }
 
-    public static String createJwt(String userName,String secretKey,Long expiredMs){
+    public static String createJwt(String email,String secretKey,Long expiredMs){
         //Claim => 유저 정보를 담아놓을 수 있음.
         Claims claims = Jwts.claims();
-        claims.put("userName",userName);
-        log.info("유저네임 {}",userName);
+        claims.put("email",email);
+        log.info("토큰이 발급되었습니다. 발급된 이메일 {}",email);
 
-        log.info("토큰이 발급되었습니다.");
         return Jwts.builder()
                 .setClaims(claims) // 유저 정보 설정
                 .setIssuedAt(new Date(System.currentTimeMillis())) // 생성 일자


### PR DESCRIPTION
[#22] 로그인 회원가입 구현

회원가입을 통해 유저 정보를 저장하고, 로그인 데이터를 입력받아 JWT 반환.

로그인의 이메일, 비밀번호 체크까지 구현 완료.

회원가입의 유효성은 아직 작업 전. 나중에 한번에 리팩토링 하는게 나을듯!?