### PR TITLE
관리자 유효성 검사 구현 완료

### DIFF
--- a/src/main/java/com/mini/anuualwork/dto/AdminDto.java
+++ b/src/main/java/com/mini/anuualwork/dto/AdminDto.java
@@ -1,14 +1,18 @@
 package com.mini.anuualwork.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.mini.anuualwork.entity.Member;
 import com.mini.anuualwork.entity.Work;
 import com.mini.anuualwork.entity.type.AnnualStatus;
 import lombok.*;
 
 import javax.validation.constraints.Future;
+import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.NotNull;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import static com.mini.anuualwork.dto.message.ValidationMessage.*;
 
@@ -59,13 +63,13 @@ public class AdminDto {
         private Long id;
 
         @NotNull(message = NOT_NULL_DATE)
-        @Future(message = DATE_REQUIRED_FUTURE)
-        private Timestamp date;
+        @FutureOrPresent(message = DATE_REQUIRED_FUTURE)
+        private LocalDate date;
 
         public Work toEntity(Member member) {
             Work work = new Work();
             work.setMember(member);
-            work.setDate(this.date.toLocalDateTime());
+            work.setDate(LocalDateTime.of(this.date, LocalTime.now()));
 
             return work;
         }

--- a/src/main/java/com/mini/anuualwork/dto/message/ValidationMessage.java
+++ b/src/main/java/com/mini/anuualwork/dto/message/ValidationMessage.java
@@ -4,5 +4,5 @@ package com.mini.anuualwork.dto.message;
 public interface ValidationMessage {
     String NOT_NULL_ID = "ID는 필수 값입니다.";
     String NOT_NULL_DATE = "Date는 필수 값입니다.";
-    String DATE_REQUIRED_FUTURE = "선택된 날짜는 오늘보다 미래 날짜여야 합니다.";
+    String DATE_REQUIRED_FUTURE = "선택된 날짜는 오늘이거나 미래 날짜여야 합니다.";
 }

--- a/src/main/java/com/mini/anuualwork/exception/message/AdminErrorMessage.java
+++ b/src/main/java/com/mini/anuualwork/exception/message/AdminErrorMessage.java
@@ -3,6 +3,8 @@ package com.mini.anuualwork.exception.message;
 public interface AdminErrorMessage {
     String NOT_FOUND_MEMBER = "존재하지 않는 유저입니다.";
     String NOT_FOUND_WORK = "존재하지 않는 당직 정보입니다.";
+    String ALREADY_EXIST_WORK = "이미 해당 날짜에 당직이 등록된 유저입니다.";
     String NOT_FOUND_ANNUAL = "존재하지 않는 연차 정보입니다.";
     String ALREADY_APPROVED_ANNUAL = "이미 승인된 연차 정보입니다.";
+    String ALREADY_EXIST_ANNUAL = "이미 해당 날짜에 연차 또는 신청 내역이 존재합니다. 해당 날짜의 연차를 확인해주세요.";
 }

--- a/src/main/java/com/mini/anuualwork/service/AdminService.java
+++ b/src/main/java/com/mini/anuualwork/service/AdminService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,10 +63,29 @@ public class AdminService {
         Member member = memberRepository.findById(dto.getId())
                 .orElseThrow(() -> new AdminException(NOT_FOUND_MEMBER));
 
+        checkAlreadyExistsWork(member, dto.getDate());
+        checkAlreadyExistAnnual(member, dto.getDate());
+
         Work work = dto.toEntity(member);
         workRepository.save(work);
 
         return new ApiDataResponse<>(new ResponseSuccess(SUCCESS_CREATE_WORK));
+    }
+
+    private void checkAlreadyExistsWork(Member member, LocalDate date) {
+        Long countWork = workRepository.findWorkByMemberAndDate(member, date.toString());
+
+        if (countWork > 0L) {
+            throw new AdminException(ALREADY_EXIST_WORK);
+        }
+    }
+
+    private void checkAlreadyExistAnnual(Member member, LocalDate date) {
+        Long countAnnual = annualRepository.findAnnualByMemberAndDate(member, date.toString());
+
+        if (countAnnual > 0L) {
+            throw new AdminException(ALREADY_EXIST_ANNUAL);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
- #58 

  - 당직 등록 날짜는 과거 날짜여서는 안된다. (오늘 날짜는 가능) ✅
  - 당직 등록 날짜에 이미 해당 유저가 당직이 존재하면 안된다. ✅
  - 당직 등록 날짜에 이미 해당 유저가 연차를 신청했거나, 연차가 존재하면 안된다. ✅